### PR TITLE
Templated Page Header and Navigation

### DIFF
--- a/lib/src/app/codealong_blog_series/blog_home.dart
+++ b/lib/src/app/codealong_blog_series/blog_home.dart
@@ -1,3 +1,4 @@
+import 'package:code_along/src/app/shared/page_template.dart';
 import 'package:flutter/material.dart';
 
 class Blog extends StatelessWidget {
@@ -5,8 +6,8 @@ class Blog extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const Scaffold(
-      body: Center(child: Text('Blog')),
+    return const PageTemplate(
+      pageContents: Center(child: Text('Blog')),
     );
   }
 }

--- a/lib/src/app/home/home.dart
+++ b/lib/src/app/home/home.dart
@@ -52,36 +52,69 @@ class _MyHomePageState extends State<MyHomePage> {
             ),
             const VerticalDivider(thickness: 1, width: 1),
             Expanded(
-              child: Card(
-                color: Colors.pink,
-                child: SizedBox(
-                  height: 200,
-                  child: Center(
-                    child: Column(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: const [
-                        Text(
-                          'CodeAlong.IO',
-                          style: TextStyle(
-                            color: Colors.white,
-                            fontWeight: FontWeight.bold,
-                            fontSize: 50,
+              child: SingleChildScrollView(
+                child: Column(
+                  children: [
+                    Card(
+                      color: Colors.pink,
+                      child: SizedBox(
+                        height: 200,
+                        child: Center(
+                          child: Column(
+                            mainAxisAlignment: MainAxisAlignment.center,
+                            children: const [
+                              Text(
+                                'CodeAlong.IO',
+                                style: TextStyle(
+                                  color: Colors.white,
+                                  fontWeight: FontWeight.bold,
+                                  fontSize: 50,
+                                ),
+                              ),
+                              SizedBox(
+                                height: 10,
+                              ),
+                              Text(
+                                'Learn along with me as we build out this blog together.',
+                                style: TextStyle(
+                                  color: Colors.white,
+                                  fontWeight: FontWeight.w100,
+                                  fontSize: 20,
+                                ),
+                              )
+                            ],
                           ),
                         ),
-                        SizedBox(
-                          height: 10,
-                        ),
-                        Text(
-                          'Learn along with me as we build out this blog together.',
-                          style: TextStyle(
-                            color: Colors.white,
-                            fontWeight: FontWeight.w100,
-                            fontSize: 20,
-                          ),
-                        )
-                      ],
+                      ),
                     ),
-                  ),
+                    Padding(
+                      padding: const EdgeInsets.symmetric(
+                        vertical: 8.0,
+                        horizontal: 10.0,
+                      ),
+                      child: Card(
+                        color: Colors.white,
+                        child: SizedBox(
+                          height: 200,
+                          child: Center(
+                            child: Column(
+                              mainAxisAlignment: MainAxisAlignment.center,
+                              children: const [
+                                Text(
+                                  'Home Page Content',
+                                  style: TextStyle(
+                                    color: Colors.black,
+                                    fontWeight: FontWeight.bold,
+                                    fontSize: 50,
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                  ],
                 ),
               ),
             )
@@ -91,5 +124,3 @@ class _MyHomePageState extends State<MyHomePage> {
     );
   }
 }
-
-// IconButton

--- a/lib/src/app/home/home.dart
+++ b/lib/src/app/home/home.dart
@@ -1,124 +1,31 @@
+import 'package:code_along/src/app/shared/page_template.dart';
 import 'package:flutter/material.dart';
-import 'package:go_router/go_router.dart';
 
-class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key, required this.title});
-
-  final String title;
-
-  @override
-  State<MyHomePage> createState() => _MyHomePageState();
-}
-
-class _MyHomePageState extends State<MyHomePage> {
-  int _selectedIndex = 0;
+class HomePage extends StatelessWidget {
+  const HomePage({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      body: SafeArea(
-        child: Row(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            NavigationRail(
-              selectedIndex: _selectedIndex,
-              groupAlignment: -1.0,
-              onDestinationSelected: (int index) {
-                setState(() {
-                  _selectedIndex = index;
-                });
-              },
-              labelType: NavigationRailLabelType.all,
-              trailing: IconButton(
-                onPressed: () => context.goNamed('settings'),
-                icon: const Icon(Icons.more_horiz_rounded),
-              ),
-              destinations: <NavigationRailDestination>[
-                NavigationRailDestination(
-                  icon: IconButton(
-                      onPressed: () => context.goNamed('home'),
-                      icon: const Icon(Icons.home_outlined)),
-                  selectedIcon: const Icon(Icons.home_filled),
-                  label: const Text('Home'),
-                ),
-                NavigationRailDestination(
-                  icon: IconButton(
-                      onPressed: () => context.goNamed('blog'),
-                      icon: const Icon(Icons.book_outlined)),
-                  selectedIcon: const Icon(Icons.book),
-                  label: const Text('Blog'),
+    return PageTemplate(
+      pageContents: Card(
+        color: Colors.white,
+        child: SizedBox(
+          height: 200,
+          child: Center(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: const [
+                Text(
+                  'Home Page Content',
+                  style: TextStyle(
+                    color: Colors.black,
+                    fontWeight: FontWeight.bold,
+                    fontSize: 50,
+                  ),
                 ),
               ],
             ),
-            const VerticalDivider(thickness: 1, width: 1),
-            Expanded(
-              child: SingleChildScrollView(
-                child: Column(
-                  children: [
-                    Card(
-                      color: Colors.pink,
-                      child: SizedBox(
-                        height: 200,
-                        child: Center(
-                          child: Column(
-                            mainAxisAlignment: MainAxisAlignment.center,
-                            children: const [
-                              Text(
-                                'CodeAlong.IO',
-                                style: TextStyle(
-                                  color: Colors.white,
-                                  fontWeight: FontWeight.bold,
-                                  fontSize: 50,
-                                ),
-                              ),
-                              SizedBox(
-                                height: 10,
-                              ),
-                              Text(
-                                'Learn along with me as we build out this blog together.',
-                                style: TextStyle(
-                                  color: Colors.white,
-                                  fontWeight: FontWeight.w100,
-                                  fontSize: 20,
-                                ),
-                              )
-                            ],
-                          ),
-                        ),
-                      ),
-                    ),
-                    Padding(
-                      padding: const EdgeInsets.symmetric(
-                        vertical: 8.0,
-                        horizontal: 10.0,
-                      ),
-                      child: Card(
-                        color: Colors.white,
-                        child: SizedBox(
-                          height: 200,
-                          child: Center(
-                            child: Column(
-                              mainAxisAlignment: MainAxisAlignment.center,
-                              children: const [
-                                Text(
-                                  'Home Page Content',
-                                  style: TextStyle(
-                                    color: Colors.black,
-                                    fontWeight: FontWeight.bold,
-                                    fontSize: 50,
-                                  ),
-                                ),
-                              ],
-                            ),
-                          ),
-                        ),
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-            )
-          ],
+          ),
         ),
       ),
     );

--- a/lib/src/app/settings/settings_home.dart
+++ b/lib/src/app/settings/settings_home.dart
@@ -1,3 +1,4 @@
+import 'package:code_along/src/app/shared/page_template.dart';
 import 'package:flutter/material.dart';
 
 class Settings extends StatelessWidget {
@@ -5,8 +6,8 @@ class Settings extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const Scaffold(
-      body: Center(child: Text('Settings')),
+    return const PageTemplate(
+      pageContents: Center(child: Text('Settings')),
     );
   }
 }

--- a/lib/src/app/shared/page_template.dart
+++ b/lib/src/app/shared/page_template.dart
@@ -1,0 +1,106 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+class PageTemplate extends StatefulWidget {
+  const PageTemplate({super.key, required this.pageContents});
+
+  final Widget pageContents;
+
+  @override
+  State<PageTemplate> createState() => _PageTemplateState();
+}
+
+class _PageTemplateState extends State<PageTemplate> {
+  int _selectedIndex = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: SafeArea(
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            NavigationRail(
+              selectedIndex: _selectedIndex,
+              groupAlignment: -1.0,
+              onDestinationSelected: (int index) {
+                setState(() {
+                  _selectedIndex = index;
+                });
+              },
+              labelType: NavigationRailLabelType.all,
+              trailing: IconButton(
+                onPressed: () => context.goNamed('settings'),
+                icon: const Icon(Icons.more_horiz_rounded),
+              ),
+              destinations: <NavigationRailDestination>[
+                NavigationRailDestination(
+                  icon: IconButton(
+                      onPressed: () => context.goNamed('home'),
+                      icon: const Icon(Icons.home_outlined)),
+                  selectedIcon: const Icon(Icons.home_filled),
+                  label: const Text('Home'),
+                ),
+                NavigationRailDestination(
+                  icon: IconButton(
+                      onPressed: () => context.goNamed('blog'),
+                      icon: const Icon(Icons.book_outlined)),
+                  selectedIcon: const Icon(Icons.book),
+                  label: const Text('Blog'),
+                ),
+              ],
+            ),
+            const VerticalDivider(thickness: 1, width: 1),
+            Expanded(
+              child: SingleChildScrollView(
+                child: Column(
+                  children: [
+                    Card(
+                      color: Colors.pink,
+                      child: SizedBox(
+                        height: 200,
+                        child: Center(
+                          child: Column(
+                            mainAxisAlignment: MainAxisAlignment.center,
+                            children: const [
+                              Text(
+                                'CodeAlong.IO',
+                                style: TextStyle(
+                                  color: Colors.white,
+                                  fontWeight: FontWeight.bold,
+                                  fontSize: 50,
+                                ),
+                              ),
+                              SizedBox(
+                                height: 10,
+                              ),
+                              Text(
+                                'Learn along with me as we build out this blog together.',
+                                style: TextStyle(
+                                  color: Colors.white,
+                                  fontWeight: FontWeight.w100,
+                                  fontSize: 20,
+                                ),
+                              )
+                            ],
+                          ),
+                        ),
+                      ),
+                    ),
+                    Padding(
+                      padding: const EdgeInsets.symmetric(
+                        vertical: 8.0,
+                        horizontal: 10.0,
+                      ),
+                      child: widget.pageContents,
+                    ),
+                  ],
+                ),
+              ),
+            )
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/routing/router.dart
+++ b/lib/src/routing/router.dart
@@ -8,9 +8,7 @@ final GoRouter goRouter = GoRouter(
     GoRoute(
       name: 'home',
       path: '/',
-      builder: (context, state) => const MyHomePage(
-        title: 'Home',
-      ),
+      builder: (context, state) => const HomePage(),
     ),
     GoRoute(
       name: 'blog',


### PR DESCRIPTION
In this body of work I've created a shared folder to be used for components that are shared across various sections of the app. In this case I turned the navigation rail and header card into a reusable widget whose 'pageContents' are provided for the specific page details as desired. 

Home, blog, and settings pages have been updated to use this template and our 'home' route now references the HomePage.