### PR TITLE
Create shared colors dark and light

### DIFF
--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -1,9 +1,11 @@
 import 'package:code_along/src/app/shared/page_template.dart';
+import 'package:code_along/src/constants/color_themes.dart';
 import 'package:flutter/material.dart';
 
 class MyApp extends StatelessWidget {
   static final ValueNotifier<ThemeMode> themeNotifier =
       ValueNotifier(ThemeMode.system);
+  static final ValueNotifier<String> themeName = ValueNotifier("System Theme");
 
   const MyApp({Key? key}) : super(key: key);
 
@@ -15,8 +17,8 @@ class MyApp extends StatelessWidget {
           return MaterialApp(
             debugShowCheckedModeBanner: false,
             title: 'CodeAlong.IO',
-            theme: ThemeData(primarySwatch: Colors.pink),
-            darkTheme: ThemeData.dark(),
+            theme: ColorThemes.lightTheme,
+            darkTheme: ColorThemes.darkTheme,
             themeMode: currentMode,
             home: const PageTemplate(),
           );

--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -5,7 +5,6 @@ import 'package:flutter/material.dart';
 class MyApp extends StatelessWidget {
   static final ValueNotifier<ThemeMode> themeNotifier =
       ValueNotifier(ThemeMode.system);
-  static final ValueNotifier<String> themeName = ValueNotifier("System Theme");
 
   const MyApp({Key? key}) : super(key: key);
 

--- a/lib/src/app/home/home.dart
+++ b/lib/src/app/home/home.dart
@@ -7,7 +7,6 @@ class HomePage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Card(
-      color: Colors.white,
       child: SizedBox(
         height: 200,
         child: Center(
@@ -15,8 +14,18 @@ class HomePage extends StatelessWidget {
             mainAxisAlignment: MainAxisAlignment.center,
             children: const [
               Text(
-                'Home Page Content',
-                style: TextStyles.homePageHeader,
+                'Welcome to CodeAlong.IO',
+                style: TextStyles.cardHeader,
+              ),
+              SizedBox(height: 10),
+              Text(
+                'Check out the blog page for the post by post build out of this blog.',
+                style: TextStyles.cardSubTitle,
+              ),
+              SizedBox(height: 20),
+              Text(
+                'Over the course of this series we\'ll learn how to deploy a flutter web app from start to finish with testing, CI/CD, and cloud datastore integration together. My intent is to show you the process of how I\'m learning flutter and hopefully inspire you to take on a new coding challenge along with me.',
+                style: TextStyles.postNormalText,
               ),
             ],
           ),

--- a/lib/src/app/settings/settings_home.dart
+++ b/lib/src/app/settings/settings_home.dart
@@ -1,4 +1,5 @@
 import 'package:code_along/src/app.dart';
+import 'package:code_along/src/constants/color_themes.dart';
 import 'package:code_along/src/constants/component_styling.dart';
 import 'package:code_along/src/constants/text_styling.dart';
 import 'package:flutter/material.dart';
@@ -14,7 +15,6 @@ class _SettingsPageState extends State<SettingsPage> {
   @override
   Widget build(BuildContext context) {
     return Card(
-      color: Colors.white,
       child: SizedBox(
         height: 200,
         child: Padding(
@@ -91,10 +91,10 @@ class _ThemeToggleButtonState extends State<ThemeToggleButton> {
             });
           },
           borderRadius: const BorderRadius.all(Radius.circular(8)),
-          selectedBorderColor: Colors.pink[700],
-          selectedColor: Colors.pink,
-          fillColor: Colors.pink[200],
-          color: Colors.pink[400],
+          selectedBorderColor: ColorThemes.settingsSelectedBorderColor,
+          selectedColor: ColorThemes.settingsSelectedColor,
+          fillColor: ColorThemes.settingsFillColor,
+          color: ColorThemes.settingsColor,
           isSelected: _selectedThemeIcon,
           children: icons,
         ),

--- a/lib/src/app/shared/page_template.dart
+++ b/lib/src/app/shared/page_template.dart
@@ -1,6 +1,7 @@
 import 'package:code_along/src/app/codealong_blog_series/blog_home.dart';
 import 'package:code_along/src/app/home/home.dart';
 import 'package:code_along/src/app/settings/settings_home.dart';
+import 'package:code_along/src/constants/color_themes.dart';
 import 'package:code_along/src/constants/text_styling.dart';
 import 'package:flutter/material.dart';
 
@@ -60,7 +61,7 @@ class _PageTemplateState extends State<PageTemplate> {
                 child: Column(
                   children: [
                     Card(
-                      color: Colors.pink,
+                      color: ColorThemes.systemColor,
                       child: SizedBox(
                         height: 200,
                         child: Center(

--- a/lib/src/constants/color_themes.dart
+++ b/lib/src/constants/color_themes.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+
+class ColorThemes {
+  static const systemColor = Colors.pink;
+  static const systemSecondaryColor = Colors.white;
+
+  static final darkTheme = ThemeData(
+    brightness: Brightness.dark,
+    colorSchemeSeed: systemColor,
+  );
+  static final lightTheme = ThemeData(
+    brightness: Brightness.light,
+    colorSchemeSeed: systemColor,
+  );
+  static final settingsSelectedBorderColor = Colors.pink[700];
+  static const settingsSelectedColor = systemColor;
+  static final settingsFillColor = Colors.pink[200];
+  static final settingsColor = Colors.pink[400];
+}

--- a/lib/src/constants/text_styling.dart
+++ b/lib/src/constants/text_styling.dart
@@ -1,23 +1,23 @@
+import 'package:code_along/src/constants/color_themes.dart';
 import 'package:flutter/material.dart';
 
 class TextStyles {
   //Used in Placeholder for home page content as the header
   static const homePageHeader = TextStyle(
-    color: Colors.black,
     fontWeight: FontWeight.bold,
     fontSize: 50,
   );
 
   //Used in Page Template App Header
   static const appHeader = TextStyle(
-    color: Colors.white,
+    color: ColorThemes.systemSecondaryColor,
     fontWeight: FontWeight.bold,
     fontSize: 50,
   );
 
   //Used in Page Template App Subtitle
   static const appSubtitle = TextStyle(
-    color: Colors.white,
+    color: ColorThemes.systemSecondaryColor,
     fontWeight: FontWeight.w100,
     fontSize: 20,
   );
@@ -26,20 +26,17 @@ class TextStyles {
   static const cardHeader = TextStyle(
     fontSize: 25,
     fontWeight: FontWeight.bold,
-    color: Colors.black,
   );
 
   //Used for Theme Settings Sub Title
   static const cardSubTitle = TextStyle(
     fontSize: 20,
     fontWeight: FontWeight.normal,
-    color: Colors.black,
   );
 
   //Used for Author, Posting Date, Contents text fields
   static const postNormalText = TextStyle(
     fontSize: 15,
     fontWeight: FontWeight.normal,
-    color: Colors.black,
   );
 }


### PR DESCRIPTION
Added a ColorThemes class for reusable color themes for light and dark modes as well as keeping the header card constant with the pink background and white text style. 